### PR TITLE
增補例外條款

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -337,3 +337,12 @@ proprietary programs.  If your program is a subroutine library, you may
 consider it more useful to permit linking proprietary applications with the
 library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.
+
+As a special exception, if you create a document which uses this font, and
+embed this font or unaltered portions of this font into the document, this
+font does not by itself cause the resulting document to be covered by the
+GNU General Public License. This exception does not however invalidate any
+other reasons why the document might be covered by the GNU General Public
+License. If you modify this font, you may extend this exception to your version
+of the font, but you are not obligated to do so. If you do not wish to do so,
+delete this exception statement from your version.


### PR DESCRIPTION
這一條款是專為 GPL 授權的字體所創的，附於 GPL 文本之後就能允許此類字體嵌入 PS、PDF 及其他相類的檔案中而不因此影響文件或文件格式本身所使用的授權。詳情見：https://www.gnu.org/licenses/gpl-faq.html#FontException
